### PR TITLE
perf: cache API responses and stop gallery image re-requests

### DIFF
--- a/backend/scripts/set-storage-cache-control.ts
+++ b/backend/scripts/set-storage-cache-control.ts
@@ -1,0 +1,73 @@
+// One-time migration: re-upload every object in the photos bucket with a
+// long cacheControl. Objects uploaded before the routes passed cacheControl
+// were stored with `no-cache`, so browsers re-validate every image on every
+// <img> mount (e.g. each gallery year switch). Filenames are random UUIDs —
+// content at a URL never changes — so a one-year max-age is safe.
+//
+// Storage metadata can't be edited in place; the only way to change it is to
+// upload the same bytes again with `upsert: true`. Safe to re-run: already
+// migrated objects are just re-uploaded with the same setting.
+//
+// Run against the environment in backend/.env:
+//   npx tsx scripts/set-storage-cache-control.ts
+// For production, run with the production SUPABASE_URL / SUPABASE_SECRET_KEY.
+
+import "dotenv/config";
+import { IMMUTABLE_CACHE, supabase } from "../src/db/supabase.js";
+
+const BUCKET = "photos";
+
+// storage.list() is per-folder, so walk the tree.
+async function listFiles(prefix: string): Promise<string[]> {
+  const { data, error } = await supabase.storage.from(BUCKET).list(prefix, {
+    limit: 1000,
+  });
+  if (error) throw new Error(`list("${prefix}") failed: ${error.message}`);
+
+  const files: string[] = [];
+  for (const entry of data ?? []) {
+    const path = prefix ? `${prefix}/${entry.name}` : entry.name;
+    // Folders come back with a null id; files have one.
+    if (entry.id) files.push(path);
+    else files.push(...(await listFiles(path)));
+  }
+  return files;
+}
+
+async function main() {
+  const files = await listFiles("");
+  console.log(`${files.length} objects in "${BUCKET}"`);
+
+  let migrated = 0;
+  for (const path of files) {
+    const { data, error: downloadError } = await supabase.storage
+      .from(BUCKET)
+      .download(path);
+    if (downloadError || !data) {
+      console.error(`SKIP ${path}: download failed (${downloadError?.message})`);
+      continue;
+    }
+
+    const { error: uploadError } = await supabase.storage
+      .from(BUCKET)
+      .upload(path, await data.arrayBuffer(), {
+        contentType: data.type || undefined,
+        cacheControl: IMMUTABLE_CACHE,
+        upsert: true,
+      });
+    if (uploadError) {
+      console.error(`SKIP ${path}: upload failed (${uploadError.message})`);
+      continue;
+    }
+
+    migrated += 1;
+    console.log(`OK   ${path}`);
+  }
+
+  console.log(`Done: ${migrated}/${files.length} migrated`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/backend/src/db/supabase.ts
+++ b/backend/src/db/supabase.ts
@@ -12,6 +12,12 @@ if (!supabaseAnonKey) {
     throw new Error("Missing SUPABASE_ANON_KEY env var");
 }
 
+// Storage uploads get random UUID filenames, so a URL's content can never
+// change — browsers may cache it forever. Passed as `cacheControl` (seconds,
+// one year) on every upload; without it objects are stored with `no-cache`
+// and every <img> remount re-validates against storage.
+export const IMMUTABLE_CACHE = "31536000";
+
 // Secret key: server-side only, bypasses RLS. Never expose to frontend.
 export const supabase = createClient(supabaseUrl, supabaseSecretKey, {
     auth: { persistSession: false },

--- a/backend/src/routes/companies.ts
+++ b/backend/src/routes/companies.ts
@@ -1,7 +1,7 @@
 import { Router, Request, Response } from "express";
 import multer from "multer";
 import { randomUUID } from "node:crypto";
-import { supabase } from "../db/supabase.js";
+import { IMMUTABLE_CACHE, supabase } from "../db/supabase.js";
 import { authenticateAdmin } from "../middleware/auth.js";
 import { Company, ReorderBody, SponsorTier } from "../types.js";
 
@@ -34,7 +34,11 @@ async function uploadToStorage(
 
   const { error } = await supabase.storage
     .from(BUCKET)
-    .upload(path, file.buffer, { contentType: file.mimetype, upsert: false });
+    .upload(path, file.buffer, {
+      contentType: file.mimetype,
+      cacheControl: IMMUTABLE_CACHE,
+      upsert: false,
+    });
 
   if (error) return null;
 

--- a/backend/src/routes/gallery.ts
+++ b/backend/src/routes/gallery.ts
@@ -1,7 +1,7 @@
 import { Router, Request, Response } from "express";
 import multer from "multer";
 import { randomUUID } from "node:crypto";
-import { supabase } from "../db/supabase.js";
+import { IMMUTABLE_CACHE, supabase } from "../db/supabase.js";
 import { authenticateAdmin } from "../middleware/auth.js";
 import {
   GalleryPhoto,
@@ -180,6 +180,7 @@ galleryRouter.post(
         .from(BUCKET)
         .upload(path, file.buffer, {
           contentType: file.mimetype,
+          cacheControl: IMMUTABLE_CACHE,
           upsert: false,
         });
 
@@ -280,6 +281,7 @@ galleryRouter.put(
       .from(BUCKET)
       .upload(path, req.file.buffer, {
         contentType: req.file.mimetype,
+        cacheControl: IMMUTABLE_CACHE,
         upsert: false,
       });
 

--- a/backend/src/routes/team.ts
+++ b/backend/src/routes/team.ts
@@ -1,7 +1,7 @@
 import { Router, Request, Response } from "express";
 import multer from "multer";
 import { randomUUID } from "node:crypto";
-import { supabase } from "../db/supabase.js";
+import { IMMUTABLE_CACHE, supabase } from "../db/supabase.js";
 import { authenticateAdmin } from "../middleware/auth.js";
 import {
   Company,
@@ -44,7 +44,11 @@ async function uploadToStorage(
 
   const { error } = await supabase.storage
     .from(BUCKET)
-    .upload(path, file.buffer, { contentType: file.mimetype, upsert: false });
+    .upload(path, file.buffer, {
+      contentType: file.mimetype,
+      cacheControl: IMMUTABLE_CACHE,
+      upsert: false,
+    });
 
   if (error) return null;
 

--- a/docs/backend-stack.md
+++ b/docs/backend-stack.md
@@ -26,7 +26,7 @@ Visitor / Admin ──► Frontend (Vite + React, Vercel)
 | Database + storage | Supabase (`@supabase/supabase-js`) | One client for Postgres queries **and** Storage |
 | Auth | Supabase Auth (Google sign-in) | Browser signs in with Google; backend verifies the access token and checks the `ADMIN_EMAILS` allowlist |
 | Captcha | Cloudflare Turnstile | Server-side verification of the public registration form (`lib/turnstile.ts`) |
-| Uploads | `multer` (in-memory) | Multipart photos → Supabase Storage |
+| Uploads | `multer` (in-memory) | Multipart photos → Supabase Storage, stored with a one-year `cacheControl` |
 | Middleware | `cors`, `morgan` | CORS locked to `FRONTEND_URL` |
 | Dev runner | `tsx watch` | Auto-restarts on file changes |
 
@@ -223,6 +223,22 @@ npm outdated && npm update                # update within semver ranges
 After changes, confirm `npm run dev` boots and `npm run build` compiles
 cleanly (TypeScript strict mode will catch type breakage), then commit
 `package.json` + `package-lock.json` together.
+
+## Storage cache headers
+
+Uploaded files get random UUID names, so the content behind a URL never
+changes. Every upload route therefore passes a one-year `cacheControl`
+(`IMMUTABLE_CACHE` in `db/supabase.ts`), letting browsers cache images
+instead of re-requesting them on every mount. Objects uploaded before this
+existed (or through the Supabase dashboard, which stores `no-cache`) keep
+their old setting; `scripts/set-storage-cache-control.ts` re-uploads
+everything in the `photos` bucket with the current one. Run it once per
+environment:
+
+```bash
+cd backend
+npx tsx scripts/set-storage-cache-control.ts   # uses SUPABASE_* from .env or the shell
+```
 
 ## Deployment
 

--- a/docs/frontend-stack.md
+++ b/docs/frontend-stack.md
@@ -49,7 +49,8 @@ frontend/
     │       ├── sponsors/         # SponsorsTab + SponsorModal + TierPanel + OtherCompaniesPanel + sponsorUtils
     │       └── registrations/    # RegistrationsTab (search, CSV export, delete)
     ├── hooks/              # Data-fetching hooks (useSchedule, useGallery, useTeam, useSponsors,
-    │                       #   useSiteSettings, useCountdown, useRegistrations) + useAuth
+    │                       #   useSiteSettings, useCountdown, useRegistrations) + useAuth.
+    │                       #   Public hooks are built on useApiData (shared response cache)
     ├── data/               # Static fallback data used when the API is unreachable
     ├── lib/
     │   ├── api.ts          # Auth-aware fetch helper (token from the Supabase session) + compressImage
@@ -74,7 +75,12 @@ sign-in and session. All data goes through the Express API (see
   fetches from the API and **falls back to the static data in `src/data/`**
   (or a sensible default for site settings) if the API is down or returns
   nothing. This means the site never renders empty — keep the static data
-  reasonably fresh.
+  reasonably fresh. All of these sit on `useApiData`, which keeps an
+  in-memory cache per API path for the session and dedupes concurrent
+  requests, so navigating between pages renders instantly from cache
+  (the register page in particular gates on `registration_open` without a
+  loading gap). Cached responses older than 60 seconds are refreshed in the
+  background after render.
 - **Admin pages** use `src/lib/api.ts`, which reads the access token from the
   Supabase session (`useAuth` exposes the same session reactively) and attaches
   it to every request. Supabase refreshes the token in the background, so there

--- a/frontend/src/components/site/PhotoGallery.tsx
+++ b/frontend/src/components/site/PhotoGallery.tsx
@@ -7,16 +7,13 @@ import { useGallery } from "../../hooks/useGallery";
 export default function PhotoGallery() {
   const { galleryData } = useGallery(); // Fetch from API (static fallback)
   const [index, setIndex] = useState(0);
-  const [direction, setDirection] = useState(1);
   const [activePhoto, setActivePhoto] = useState<ActivePhoto | null>(null);
 
   function handleNext() {
-    setDirection(1);
     setIndex((prev) => (prev + 1) % galleryData.length);
   }
 
   function handlePrev() {
-    setDirection(-1);
     setIndex((prev) => (prev - 1 + galleryData.length) % galleryData.length);
   }
 
@@ -67,18 +64,26 @@ export default function PhotoGallery() {
           <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m15 18-6-6 6-6" /></svg>
         </button>
 
-        {/* Sliding viewport */}
-        <div className="relative w-full overflow-hidden px-12 md:px-5 py-2">
-          <AnimatePresence mode="wait" custom={direction}>
-            <Slideshow
-              key={current.year}
-              year={current.year}
-              photos={current.photos}
-              direction={direction}
-              onPhotoClick={(photo, idx) => setActivePhoto({ photo, year: current.year, idx })}
-              activePhoto={activePhoto}
-            />
-          </AnimatePresence>
+        {/* Sliding viewport. Every year stays mounted, stacked in the same
+            spot, and only the active one is visible — unmounting a year would
+            drop its <img> elements and re-request every photo on each switch
+            (including the 10s auto-advance). The inactive wrappers are
+            absolute so the active year alone sets the container height. */}
+        <div className="relative w-full overflow-hidden py-2">
+          {galleryData.map((slide, i) => (
+            <div
+              key={slide.year}
+              className={`w-full px-12 md:px-5 ${i === index ? "" : "absolute inset-0 pointer-events-none"}`}
+            >
+              <Slideshow
+                year={slide.year}
+                photos={slide.photos}
+                active={i === index}
+                onPhotoClick={(photo, idx) => setActivePhoto({ photo, year: slide.year, idx })}
+                activePhoto={activePhoto}
+              />
+            </div>
+          ))}
         </div>
 
         {/* Right Arrow */}

--- a/frontend/src/components/site/Slideshow.tsx
+++ b/frontend/src/components/site/Slideshow.tsx
@@ -13,10 +13,13 @@ export interface ActivePhoto {
 // The grid itself doesn't visually animate — it just orchestrates its children.
 // `staggerChildren` means each child starts its animation 0.08s after the previous one.
 // `delayChildren` adds a small pause before the first child starts.
+// Both years are mounted at once, stacked in the same spot, so entering
+// children wait (delayChildren) until the outgoing year's quick exit has
+// finished — otherwise the two grids would crossfade on top of each other.
 const gridVariants: Variants = {
   enter:  { transition: { staggerChildren: 0.08, delayChildren: 0.05 } },
-  center: { transition: { staggerChildren: 0.08, delayChildren: 0.05 } },
-  exit:   { transition: { staggerChildren: 0.05, staggerDirection: -1 } },
+  center: { transition: { staggerChildren: 0.08, delayChildren: 0.35 } },
+  exit:   { transition: { staggerChildren: 0.03, staggerDirection: -1 } },
   // staggerDirection: -1 means the exit stagger runs in reverse order (last photo exits first)
 };
 
@@ -26,7 +29,9 @@ const gridVariants: Variants = {
 const photoVariants: Variants = {
   enter:  { opacity: 0, y: 20, scale: 0.97 },   // starts below and faded
   center: { opacity: 1, y: 0,  scale: 1    },   // fully visible, in position
-  exit:   { opacity: 0, y: -10, scale: 0.97 },  // exits upward and fades
+  // Exits upward and fades — faster than the 0.4s entrance so it is done
+  // before the incoming year's delayChildren elapses.
+  exit:   { opacity: 0, y: -10, scale: 0.97, transition: { duration: 0.2 } },
 };
 
 interface ParallaxPhotoProps {
@@ -107,29 +112,44 @@ function ParallaxPhoto({ photo, index, year, onPhotoClick, isActive }: ParallaxP
 interface SlideshowProps {
   year: string;
   photos: GalleryPhoto[];
-  /** +1 or -1 — kept for future use / dot clicks. */
-  direction?: number;
+  /** Whether this is the year currently shown. The slideshow stays mounted
+   *  either way (so its images are requested once, ever); this only drives
+   *  the show/hide animation. */
+  active: boolean;
   onPhotoClick?: (photo: GalleryPhoto, idx: number) => void;
   activePhoto?: ActivePhoto | null;
 }
 
+// Simple fade for the year label — it has no y-travel of its own, but being
+// a motion child it still slots into the parent's stagger orchestration.
+const labelVariants: Variants = {
+  enter:  { opacity: 0 },
+  center: { opacity: 1 },
+  exit:   { opacity: 0, transition: { duration: 0.2 } },
+};
+
 // ─── Slideshow ────────────────────────────────────────────────────────────────
-export default function Slideshow({ year, photos, onPhotoClick, activePhoto }: SlideshowProps) {
+export default function Slideshow({ year, photos, active, onPhotoClick, activePhoto }: SlideshowProps) {
   return (
     // motion.div is the grid parent — it holds the stagger orchestration.
-    // `initial`, `animate`, `exit` here match the keys in gridVariants.
+    // `initial` and `animate` here match the keys in gridVariants; toggling
+    // `active` animates between them without unmounting anything.
     // Motion automatically passes these variant names down to all motion.* children.
     <motion.div
       variants={gridVariants}
-      initial="enter"
-      animate="center"
-      exit="exit"
+      initial={active ? "enter" : "exit"}
+      animate={active ? "center" : "exit"}
+      aria-hidden={!active}
       className="w-full"
     >
       {/* Year label */}
-      <h3 className="font-mono uppercase tracking-widest text-lg md:text-xl mb-6 text-center">
+      <motion.h3
+        variants={labelVariants}
+        transition={{ duration: 0.4, ease: "easeOut" }}
+        className="font-mono uppercase tracking-widest text-lg md:text-xl mb-6 text-center"
+      >
         <span className="font-bold text-ultraviolet">HackKnight</span> <span className="font-bold text-white">{year}</span>
-      </h3>
+      </motion.h3>
 
       {/* Responsive photo grid: 2 cols on mobile, 3 on tablet/desktop */}
       <div className="grid grid-cols-2 md:grid-cols-3 gap-3 md:gap-4">

--- a/frontend/src/hooks/useApiData.ts
+++ b/frontend/src/hooks/useApiData.ts
@@ -1,0 +1,99 @@
+// Shared fetch-on-mount hook with an in-memory, session-lifetime cache.
+//
+// Every public page used to fetch its data fresh on each mount, so every
+// navigation rendered a loading state (a blank register page, static
+// fallbacks flashing before real data) while the same endpoints were hit
+// again. Caching the last response per path lets a remount render the real
+// data instantly; when a cached entry is older than STALE_MS the hook
+// serves it anyway and revalidates in the background, so admin edits still
+// propagate without a reload.
+
+import { useEffect, useState } from "react";
+
+const API_URL = import.meta.env.VITE_API_URL ?? "";
+
+// How long a cached response is served without a background refresh. Admin
+// changes (e.g. the registration toggle) can lag by up to this much for a
+// visitor who keeps navigating without reloading.
+const STALE_MS = 60_000;
+
+interface CacheEntry {
+  data: unknown;
+  fetchedAt: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+const inflight = new Map<string, Promise<unknown>>();
+
+// Deduplicates concurrent requests for the same path (the Navbar and the
+// countdown both read /settings on first paint) and records the result.
+function load(path: string): Promise<unknown> {
+  const pending = inflight.get(path);
+  if (pending) return pending;
+
+  const request = (async () => {
+    const res = await fetch(`${API_URL}${path}`);
+    if (!res.ok) throw new Error(`Failed to fetch ${path}`);
+    const data: unknown = await res.json();
+    cache.set(path, { data, fetchedAt: Date.now() });
+    return data;
+  })().finally(() => inflight.delete(path));
+
+  inflight.set(path, request);
+  return request;
+}
+
+// Resolves with a fresh-enough cached value, otherwise (re)fetches. A stale
+// entry still refetches, but the hook keeps showing it until the fresh
+// response lands (stale-while-revalidate).
+function read(path: string): Promise<unknown> {
+  const entry = cache.get(path);
+  if (entry && Date.now() - entry.fetchedAt < STALE_MS) {
+    return Promise.resolve(entry.data);
+  }
+  return load(path);
+}
+
+// Pass `enabled: false` to skip the fetch entirely (e.g. when a caller
+// already has its own values, such as the admin live preview).
+//
+// `data` is undefined until the first response for that path arrives;
+// callers keep supplying their own fallbacks, so an unreachable API still
+// degrades to the bundled behavior.
+export function useApiData<T>(
+  path: string,
+  { enabled = true }: { enabled?: boolean } = {},
+) {
+  const cached = cache.get(path);
+  const [data, setData] = useState<T | undefined>(
+    cached?.data as T | undefined,
+  );
+  const [loading, setLoading] = useState(enabled && cached === undefined);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    let cancelled = false;
+
+    read(path).then(
+      (fresh) => {
+        if (cancelled) return;
+        setData(fresh as T);
+        setLoading(false);
+      },
+      (err) => {
+        if (cancelled) return;
+        // Keep any previously cached data; only the refresh failed.
+        setError(err as Error);
+        setLoading(false);
+      },
+    );
+
+    return () => {
+      cancelled = true;
+    };
+  }, [path, enabled]);
+
+  return { data, loading, error };
+}

--- a/frontend/src/hooks/useGallery.ts
+++ b/frontend/src/hooks/useGallery.ts
@@ -1,41 +1,17 @@
 // Fetches gallery years + photos from the Express API.
 // Falls back to the bundled static data if the API is unreachable.
+// Cached across navigations by useApiData, so revisiting the page renders
+// the fetched photos immediately instead of re-requesting them.
 
-import { useState, useEffect } from "react";
+import { useApiData } from "./useApiData";
 import staticGallery from "../data/gallery";
 import type { GalleryYear } from "../types";
 
-const API_URL = import.meta.env.VITE_API_URL ?? "";
-
 export function useGallery() {
-  const [galleryData, setGalleryData] = useState<GalleryYear[]>(staticGallery);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    async function load() {
-      try {
-        const res = await fetch(`${API_URL}/gallery`);
-        if (!res.ok) throw new Error("Failed to fetch gallery");
-        const data: GalleryYear[] = await res.json();
-        if (cancelled) return;
-        // The API shape ({ year, photos: [{ src, alt }] }) matches the
-        // static data, so components consume it unchanged.
-        if (Array.isArray(data) && data.length > 0) setGalleryData(data);
-      } catch (err) {
-        if (!cancelled) setError(err as Error);
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    }
-
-    load();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
+  const { data, loading, error } = useApiData<GalleryYear[]>("/gallery");
+  // The API shape ({ year, photos: [{ src, alt }] }) matches the
+  // static data, so components consume it unchanged.
+  const galleryData =
+    Array.isArray(data) && data.length > 0 ? data : staticGallery;
   return { galleryData, loading, error };
 }

--- a/frontend/src/hooks/useSchedule.ts
+++ b/frontend/src/hooks/useSchedule.ts
@@ -1,14 +1,15 @@
 // Fetches schedule events + day headers from the Express API.
 // Falls back to the bundled static data if the API is unreachable.
+// Cached across navigations by useApiData, so revisiting the page renders
+// the fetched schedule immediately instead of re-requesting it.
 
-import { useState, useEffect } from "react";
+import { useMemo } from "react";
+import { useApiData } from "./useApiData";
 import {
   scheduleEvents as staticEvents,
   scheduleDays as staticDays,
 } from "../data/schedule";
 import type { EventColor, ScheduleDay, ScheduleEvent } from "../types";
-
-const API_URL = import.meta.env.VITE_API_URL ?? "";
 
 /** Raw row from the Express API (snake_case DB columns). */
 interface ScheduleEventRow {
@@ -35,45 +36,23 @@ function mapEvent(e: ScheduleEventRow): ScheduleEvent {
 }
 
 export function useSchedule() {
-  const [events, setEvents] = useState<ScheduleEvent[]>(staticEvents);
-  const [days, setDays] = useState<ScheduleDay[]>(staticDays);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
+  const ev = useApiData<ScheduleEventRow[]>("/schedule");
+  const day = useApiData<ScheduleDay[]>("/schedule/days");
 
-  useEffect(() => {
-    let cancelled = false;
+  const events = useMemo(
+    () =>
+      Array.isArray(ev.data) && ev.data.length > 0
+        ? ev.data.map(mapEvent)
+        : staticEvents,
+    [ev.data],
+  );
+  const days =
+    Array.isArray(day.data) && day.data.length > 0 ? day.data : staticDays;
 
-    async function load() {
-      try {
-        const [evRes, dayRes] = await Promise.all([
-          fetch(`${API_URL}/schedule`),
-          fetch(`${API_URL}/schedule/days`),
-        ]);
-        if (!evRes.ok || !dayRes.ok) {
-          throw new Error("Failed to fetch schedule");
-        }
-        const [evData, dayData]: [ScheduleEventRow[], ScheduleDay[]] =
-          await Promise.all([evRes.json(), dayRes.json()]);
-        if (cancelled) return;
-        if (Array.isArray(evData) && evData.length > 0) {
-          setEvents(evData.map(mapEvent));
-        }
-        if (Array.isArray(dayData) && dayData.length > 0) {
-          setDays(dayData);
-        }
-      } catch (err) {
-        // Keep the static fallback already in state.
-        if (!cancelled) setError(err as Error);
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    }
-
-    load();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  return { events, days, loading, error };
+  return {
+    events,
+    days,
+    loading: ev.loading || day.loading,
+    error: ev.error ?? day.error,
+  };
 }

--- a/frontend/src/hooks/useSiteSettings.ts
+++ b/frontend/src/hooks/useSiteSettings.ts
@@ -1,42 +1,23 @@
 // Fetches the site_settings key/value map from the Express API (Misc admin
 // tab). Callers read individual keys and supply their own fallback defaults,
 // so an unreachable API degrades to the bundled behavior.
+//
+// Backed by the shared useApiData cache: after the first paint fetches the
+// map (the Navbar does on every public page), later navigations — clicking
+// Apply Now in particular — render from the cached value instantly instead
+// of holding a loading state.
 
-import { useState, useEffect } from "react";
+import { useApiData } from "./useApiData";
 import type { SiteSettings } from "../types";
 
-const API_URL = import.meta.env.VITE_API_URL ?? "";
+const EMPTY: SiteSettings = {};
 
 // Pass `enabled: false` to skip the fetch entirely (e.g. when a caller
 // already has its own values, such as the admin live preview).
 export function useSiteSettings({ enabled = true }: { enabled?: boolean } = {}) {
-  const [settings, setSettings] = useState<SiteSettings>({});
-  const [loading, setLoading] = useState(enabled);
-  const [error, setError] = useState<Error | null>(null);
-
-  useEffect(() => {
-    if (!enabled) return;
-    let cancelled = false;
-
-    async function load() {
-      try {
-        const res = await fetch(`${API_URL}/settings`);
-        if (!res.ok) throw new Error("Failed to fetch settings");
-        const data: SiteSettings = await res.json();
-        if (cancelled) return;
-        if (data && typeof data === "object") setSettings(data);
-      } catch (err) {
-        if (!cancelled) setError(err as Error);
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    }
-
-    load();
-    return () => {
-      cancelled = true;
-    };
-  }, [enabled]);
-
+  const { data, loading, error } = useApiData<SiteSettings>("/settings", {
+    enabled,
+  });
+  const settings = data && typeof data === "object" ? data : EMPTY;
   return { settings, loading, error };
 }

--- a/frontend/src/hooks/useSponsors.ts
+++ b/frontend/src/hooks/useSponsors.ts
@@ -1,12 +1,13 @@
 // Fetches sponsors from the Express API (backed by the companies table —
 // a company is a sponsor once it has a sponsor_tier).
 // Falls back to the bundled static data if the API is unreachable.
+// Cached across navigations by useApiData, so revisiting the page renders
+// the fetched sponsors immediately instead of re-requesting them.
 
-import { useState, useEffect } from "react";
+import { useMemo } from "react";
+import { useApiData } from "./useApiData";
 import { sponsors as staticSponsors } from "../data/sponsors";
 import type { Sponsor, SponsorTier } from "../types";
-
-const API_URL = import.meta.env.VITE_API_URL ?? "";
 
 const TIER_RANK: Record<SponsorTier, number> = {
   platinum: 0,
@@ -37,43 +38,20 @@ function mapCompany(c: CompanyRow & { sponsor_tier: SponsorTier }): Sponsor {
 }
 
 export function useSponsors() {
-  const [sponsors, setSponsors] = useState<Sponsor[]>(staticSponsors);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    async function load() {
-      try {
-        const res = await fetch(`${API_URL}/companies`);
-        if (!res.ok) throw new Error("Failed to fetch sponsors");
-        const data: CompanyRow[] = await res.json();
-        if (cancelled) return;
-        const mapped = (Array.isArray(data) ? data : [])
-          .filter(
-            (c): c is CompanyRow & { sponsor_tier: SponsorTier } =>
-              !!c.sponsor_tier,
-          )
-          .map(mapCompany)
-          .sort(
-            (a, b) =>
-              TIER_RANK[a.tier] - TIER_RANK[b.tier] ||
-              a.name.localeCompare(b.name),
-          );
-        if (mapped.length > 0) setSponsors(mapped);
-      } catch (err) {
-        if (!cancelled) setError(err as Error);
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    }
-
-    load();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
+  const { data, loading, error } = useApiData<CompanyRow[]>("/companies");
+  const sponsors = useMemo(() => {
+    const mapped = (Array.isArray(data) ? data : [])
+      .filter(
+        (c): c is CompanyRow & { sponsor_tier: SponsorTier } =>
+          !!c.sponsor_tier,
+      )
+      .map(mapCompany)
+      .sort(
+        (a, b) =>
+          TIER_RANK[a.tier] - TIER_RANK[b.tier] ||
+          a.name.localeCompare(b.name),
+      );
+    return mapped.length > 0 ? mapped : staticSponsors;
+  }, [data]);
   return { sponsors, loading, error };
 }

--- a/frontend/src/hooks/useTeam.ts
+++ b/frontend/src/hooks/useTeam.ts
@@ -1,11 +1,12 @@
 // Fetches team members from the Express API.
 // Falls back to the bundled static data if the API is unreachable.
+// Cached across navigations by useApiData, so revisiting the page renders
+// the fetched members immediately instead of re-requesting them.
 
-import { useState, useEffect } from "react";
+import { useMemo } from "react";
+import { useApiData } from "./useApiData";
 import { teamMembers as staticTeam } from "../data/team";
 import type { TeamMember } from "../types";
-
-const API_URL = import.meta.env.VITE_API_URL ?? "";
 
 /** Raw row from the Express API (snake_case DB columns). */
 interface TeamMemberRow {
@@ -41,34 +42,13 @@ function mapMember(m: TeamMemberRow): TeamMember {
 }
 
 export function useTeam() {
-  const [teamMembers, setTeamMembers] = useState<TeamMember[]>(staticTeam);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    async function load() {
-      try {
-        const res = await fetch(`${API_URL}/team`);
-        if (!res.ok) throw new Error("Failed to fetch team");
-        const data: TeamMemberRow[] = await res.json();
-        if (cancelled) return;
-        if (Array.isArray(data) && data.length > 0) {
-          setTeamMembers(data.map(mapMember));
-        }
-      } catch (err) {
-        if (!cancelled) setError(err as Error);
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    }
-
-    load();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
+  const { data, loading, error } = useApiData<TeamMemberRow[]>("/team");
+  const teamMembers = useMemo(
+    () =>
+      Array.isArray(data) && data.length > 0
+        ? data.map(mapMember)
+        : staticTeam,
+    [data],
+  );
   return { teamMembers, loading, error };
 }


### PR DESCRIPTION
## What

Clicking Apply Now showed a blank beat while /api/settings refetched, every page navigation refetched all six public endpoints, and the gallery re-requested every photo on each year switch (including the 10s auto-advance).

## Changes

- **Shared API cache (frontend).** New `useApiData` hook: in-memory, session-lifetime cache per API path with request deduping. All five public data hooks now sit on it, so revisiting a page renders instantly from cache and refreshes in the background once the entry is older than 60s. The register page gates on `registration_open` with no loading gap.
- **Gallery keeps years mounted.** `PhotoGallery`/`Slideshow` no longer unmount the grid on year switch; the same enter/exit variants are driven by an `active` prop, so images are requested once per session. The exit was quickened and the incoming year delayed so the swap still reads as exit-then-enter.
- **Storage cache headers (backend).** All four upload paths pass a one-year `cacheControl` (filenames are random UUIDs, so URLs are immutable). `scripts/set-storage-cache-control.ts` re-uploads existing objects with the same setting.
- **Docs** updated in `frontend-stack.md` and `backend-stack.md`.

## After merge

Run the one-time migration against production so existing photos pick up the new header (verified end to end locally):

```
cd backend
npx tsx scripts/set-storage-cache-control.ts   # with production SUPABASE_URL / SUPABASE_SECRET_KEY
```

## Verification

Driven headless browser against local dev and production:

- Click Apply Now to form visible: ~810ms before, ~390ms after (page transition only), even with 400ms of injected /api/settings latency. The Opening Soon page never flashes.
- Home load: 8 API calls before (settings fetched twice), 6 after; register visit, back home, register again added zero calls.
- Gallery: 36 webp resource entries after load, unchanged after two manual switches plus an auto-advance cycle. Lightbox and transition sequencing verified by screenshot.
- `tsc -b` and ESLint pass for frontend and backend.